### PR TITLE
set canceled before setting opened flag

### DIFF
--- a/iron-overlay-behavior.html
+++ b/iron-overlay-behavior.html
@@ -202,16 +202,16 @@ context. You should place this element as a child of `<body>` whenever possible.
      * Close the overlay.
      */
     close: function() {
-      this.opened = false;
       this._setCanceled(false);
+      this.opened = false;
     },
 
     /**
      * Cancels the overlay.
      */
     cancel: function() {
-      this.opened = false,
       this._setCanceled(true);
+      this.opened = false;
     },
 
     _ensureSetup: function() {


### PR DESCRIPTION
Opening an overlay a 2nd time and closing it causes the closingReason.canceled flag to be set to false when it should be true.